### PR TITLE
Define a setter for operation input variables

### DIFF
--- a/lib/composable_operations/operation.rb
+++ b/lib/composable_operations/operation.rb
@@ -65,6 +65,7 @@ module ComposableOperations
           else
             names.each_with_index do |name, index|
               define_method(name) { input[index] }
+              define_method("#{name}=") { |value| input[index] = value }
             end
           end
         end

--- a/spec/composable_operations/operation_input_processing_spec.rb
+++ b/spec/composable_operations/operation_input_processing_spec.rb
@@ -117,6 +117,22 @@ describe ComposableOperations::Operation, "input processing:" do
 
   end
 
+  describe "An operation that takes a named argument and uses the setter for the named argument" do
+
+    subject(:operation) do
+      Class.new(described_class) do
+        processes :some_value
+        def execute
+          self.some_value = "changed"
+          self.some_value
+        end
+      end
+    end
+
+    it { should succeed_to_perform.when_initialized_with("unchanged").and_return("changed") }
+
+  end
+
 end
 
 describe ComposableOperations::ComposedOperation, "input processing:" do


### PR DESCRIPTION
Until now the input variables defined with `processes` in a operation
were read-only. With this change it's possible to change the value of
the variables when executing the operation.
