### PR TITLE
Positional arguments to property mapping

### DIFF
--- a/composable_operations.gemspec
+++ b/composable_operations.gemspec
@@ -19,7 +19,7 @@ multiple of these operations in operation pipelines.}
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "smart_properties", "~> 1.0"
+  spec.add_dependency "smart_properties", "~> 1.10"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "pry", "~> 0.9.0"

--- a/spec/composable_operations/operation_input_processing_spec.rb
+++ b/spec/composable_operations/operation_input_processing_spec.rb
@@ -16,19 +16,6 @@ describe ComposableOperations::Operation, "input processing:" do
     it { is_expected.to succeed_to_perform.when_initialized_with(input).and_return(input) }
   end
 
-  describe "An operation that takes no arguments except for a Hash of additional options" do
-    subject(:operation) do
-      Class.new(described_class) do
-        def execute
-          input
-        end
-      end
-    end
-
-    it { is_expected.to succeed_to_perform.when_initialized_with(key: :value).and_return([]) }
-    it { is_expected.to succeed_to_perform.when_initialized_with(1, 2, 3, key: :value).and_return([1, 2, 3]) }
-  end
-
   describe "An operation that takes a Hash as input and an Hash of additional options" do
     let(:input) { { food: nil } }
 
@@ -71,7 +58,6 @@ describe ComposableOperations::Operation, "input processing:" do
     end
 
     it { is_expected.to succeed_to_perform.when_initialized_with(1, 2).and_return([1, 2]) }
-    it { is_expected.to succeed_to_perform.when_initialized_with(1, 2, 3).and_return([1, 2, 3]) }
   end
 
   describe "An operation that takes multiple arguments as input where the last of these arguments is a Hash" do
@@ -89,19 +75,6 @@ describe ComposableOperations::Operation, "input processing:" do
     it { is_expected.to succeed_to_perform.when_initialized_with(1, 2, operator: :*).and_return(2) }
   end
 
-  describe "An operation that takes multiple arguments as input where the last of these arguments is a Hash, as well as, a Hash of additional options" do
-    subject(:operation) do
-      Class.new(described_class) do
-        processes :some_value, :yet_another_value, :a_hash
-        def execute
-          a_hash
-        end
-      end
-    end
-
-    it { is_expected.to succeed_to_perform.when_initialized_with(1, 2, {food: "chunky bacon"}, { additional: :options }).and_return(food: "chunky bacon") }
-  end
-
   describe "An operation that takes a named argument and uses the setter for the named argument" do
     subject(:operation) do
       Class.new(described_class) do
@@ -114,6 +87,21 @@ describe ComposableOperations::Operation, "input processing:" do
     end
 
     it { is_expected.to succeed_to_perform.when_initialized_with("unchanged").and_return("changed") }
+  end
+
+  describe "An operation that manually defines a property for its first input argument that upcases its assgined value" do
+    subject(:operation) do
+      Class.new(described_class) do
+        property :text, converts: :upcase
+        processes :text
+
+        def execute
+          text
+        end
+      end
+    end
+
+    it { is_expected.to succeed_to_perform.when_initialized_with("hello").and_return("HELLO") }
   end
 end
 

--- a/spec/composable_operations/operation_spec.rb
+++ b/spec/composable_operations/operation_spec.rb
@@ -2,14 +2,15 @@ require 'spec_helper'
 
 describe ComposableOperations::Operation do
   context "that always returns nil when executed" do
-    subject(:nil_operation) do
-      class << (operation = described_class.new(''))
+    let(:nil_operation) do
+       Class.new(described_class) do
         def execute
           nil
         end
       end
-      operation
     end
+
+    subject { nil_operation.new }
 
     it { is_expected.to succeed_to_perform.and_return(nil) }
   end
@@ -17,13 +18,14 @@ describe ComposableOperations::Operation do
   context "that always halts and returns its original input" do
     let(:halting_operation) do
       Class.new(described_class) do
+        processes :message
         def execute
           halt "Full stop!", input.first
         end
       end
     end
 
-    let(:halting_operation_instance) do
+    subject(:halting_operation_instance) do
       halting_operation.new("Test")
     end
 


### PR DESCRIPTION
The positional arguments the initialize method of an `Operation` takes are now mapped to `SmartProperties`. Before, they were tracked in a separate array. Using `SmartProperties` enables to define basic restrictions on the input arguments of an `Operation` more efficiently. If no custom property has been defined, `.processes` defines a required `property` that does not do any conversion or acceptance checking.

Closes #8 